### PR TITLE
Update footerLinks.tsx

### DIFF
--- a/src/constants/footerLinks.tsx
+++ b/src/constants/footerLinks.tsx
@@ -35,7 +35,7 @@ export const contactsLinks = [
 	{
 		id: 4,
 		name: <>Discord</>,
-		href: 'https://discord.gg/peredelano',
+		href: 'https://discord.gg/eB9QF9RJgu',
 	},
 	{
 		id: 5,


### PR DESCRIPTION
Персональная ссылка-приглашение больше не работает (нет достаточного количества бустов сервера), поэтому необходимо заменить ее на обычную вечную ссылку-приглашение.